### PR TITLE
Ignore n815 warnings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,5 +5,6 @@ universal = 0
 # E129: some indentation
 # E731: don't assign a lambda expression
 # W503, W504: line break before/after binary operators
-ignore = E129,E731,W503,W504
+# N815: mixedCase in class scope
+ignore = E129,E731,W503,W504,N815
 max-line-length=80


### PR DESCRIPTION
These are incompatible with the twisted coding style.